### PR TITLE
fix: upgrade to liblzma v0.4.6 to support ARM64 payloads

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Extract versions
         shell: bash
@@ -57,7 +57,7 @@ jobs:
             outname: linux-arm64
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -103,7 +103,7 @@ jobs:
           tar -czf "$NAME.tar.gz" -C pkg .
           sha256sum "$NAME.tar.gz" > "$NAME.sha256"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.outname }}
           path: |
@@ -126,7 +126,7 @@ jobs:
             outname: windows-gnu-x86_64
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -147,7 +147,7 @@ jobs:
           7z a "$NAME.zip" ./pkg/*
           sha256sum "$NAME.zip" > "$NAME.sha256"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.outname }}
           path: |
@@ -169,7 +169,7 @@ jobs:
             outname: macos-arm64
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -191,7 +191,7 @@ jobs:
           tar -czf "$NAME.tar.gz" -C pkg .
           shasum -a 256 "$NAME.tar.gz" > "$NAME.sha256"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.outname }}
           path: |
@@ -206,7 +206,7 @@ jobs:
     needs: version-check
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -240,7 +240,7 @@ jobs:
           zip -j "$NAME.zip" pkg/*
           sha256sum "$NAME.zip" > "$NAME.sha256"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: android-arm64
           path: |
@@ -257,7 +257,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -28,7 +28,7 @@ jobs:
             outname: otaripper-linux-arm64
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -76,7 +76,7 @@ jobs:
           tar -czf ${{ matrix.outname }}.tar.gz -C pkg .
           sha256sum ${{ matrix.outname }}.tar.gz > ${{ matrix.outname }}.sha256
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.outname }}
           path: |
@@ -98,7 +98,7 @@ jobs:
             outname: otaripper-windows-gnu-x86_64
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -120,7 +120,7 @@ jobs:
           zip -r ${{ matrix.outname }}.zip pkg
           sha256sum ${{ matrix.outname }}.zip > ${{ matrix.outname }}.sha256
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.outname }}
           path: |
@@ -141,7 +141,7 @@ jobs:
             outname: otaripper-macos-arm64
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -163,7 +163,7 @@ jobs:
           tar -czf ${{ matrix.outname }}.tar.gz -C pkg .
           shasum -a 256 ${{ matrix.outname }}.tar.gz > ${{ matrix.outname }}.sha256
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.outname }}
           path: |
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -218,7 +218,7 @@ jobs:
           zip -j otaripper-android-arm64.zip pkg/*
           sha256sum otaripper-android-arm64.zip > otaripper-android-arm64.sha256
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: otaripper-android-arm64
           path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "liblzma"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,17 +538,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "memchr"
@@ -672,6 +681,7 @@ dependencies = [
  "hex",
  "indicatif",
  "libc",
+ "liblzma",
  "memmap2",
  "mimalloc",
  "prost",
@@ -679,7 +689,6 @@ dependencies = [
  "ring",
  "sysinfo",
  "tempfile",
- "xz2",
  "zip",
 ]
 
@@ -1182,15 +1191,6 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rayon = "1.12.0"
 ring = "0.17.14"
 sysinfo = "0.38.4"
 tempfile = "3.27.0"
-xz2 = "0.1.7"
+liblzma = "0.4.6"
 zip = { version = "8.6.0", default-features = false, features = [
   "deflate",
   "bzip2",
@@ -39,7 +39,7 @@ libc = "0.2.186"
 
 # Compatibility: Static liblzma only on musl to avoid glibc x86-64-v4 issues
 [target.'cfg(target_env = "musl")'.dependencies]
-xz2 = { version = "0.1.7", features = ["static"] }
+liblzma = { version = "0.4.6", features = ["static"] }
 
 
 [profile.release]

--- a/src/cmd/extractor.rs
+++ b/src/cmd/extractor.rs
@@ -980,7 +980,7 @@ impl<'a> Extractor<'a> {
             }
             Type::ReplaceXz => {
                 let data = self.extract_data(op, payload)?;
-                let mut decoder = xz2::read::XzDecoder::new(data);
+                let mut decoder = liblzma::read::XzDecoder::new(data);
                 self.run_op_replace(&mut decoder, &mut dst_extents, block_size, simd)?;
                 Ok(total_dst_size)
             }


### PR DESCRIPTION
Swapped the abandoned xz2 crate for the maintained liblzma fork.

- Updates the underlying C-engine to XZ 5.8
- Fixes decompression crashes on modern Android OTAs that utilize the ARM64 BCJ filter
- Retains compatibility with static musl builds
- Bumped GitHub Actions versions to clear out Node 20 deprecation warnings in the CI

TL;DR: This replaces the previous CI-based workaround and cleanly resolves the local DX "silent footgun" issue, by using an official crates.io release, it ensures cargo build works safely out-of-the-box everywhere with zero environment setup.