### PR TITLE
instant zip extraction via direct memory mapping

### DIFF
--- a/src/cmd/extractor.rs
+++ b/src/cmd/extractor.rs
@@ -47,6 +47,7 @@ thread_local! {
 
 pub enum PayloadSource {
     Mapped(Mmap),
+    MappedOffset(Mmap, usize),
     Owned(Vec<u8>),
     Temp(Mmap, NamedTempFile),
 }
@@ -95,6 +96,7 @@ impl Deref for PayloadSource {
     fn deref(&self) -> &Self::Target {
         match self {
             PayloadSource::Mapped(mmap) => mmap,
+            PayloadSource::MappedOffset(mmap, offset) => &mmap[*offset..],
             PayloadSource::Owned(vec) => vec,
             PayloadSource::Temp(mmap, _) => mmap,
         }
@@ -1171,6 +1173,12 @@ impl<'a> Extractor<'a> {
                 .context("File has ZIP magic but is not a valid ZIP archive")?;
 
             if let Ok(mut zipfile) = archive.by_name("payload.bin") {
+                if zipfile.compression() == zip::CompressionMethod::Stored {
+                    let base_offset = zipfile.data_start().ok_or_else(|| anyhow::anyhow!("Failed to determine the starting byte offset of payload.bin inside the ZIP"))?;
+                    let mmap = unsafe { Mmap::map(&file) }.context("failed to mmap zip file")?;
+                    return Ok(PayloadSource::MappedOffset(mmap, base_offset as usize));
+                }
+
                 let payload_size = zipfile.size();
 
                 // LIGHTWEIGHT RAM CHECK: Only refresh memory stats to minimize overhead


### PR DESCRIPTION
This is a pretty big one for extraction speeds.

The Problem:
Before this, whenever we feed an update.zip, it had to unzip the entire payload.bin file to a temp file (or a massive RAM buffer) before it could even start the actual work, and for larger OTAs, this caused a unnecessary startup delay and basically just burned through drive lifespan for no reason. 

The Fix:
I added a new MappedOffset variant to PayloadSource, Now, if the zip is uncompressed (STORED method, which is standard for pretty much all OTAs), the tool just memory maps the original .zip straight from the disk. It uses a clever offset to jump directly to where the payload data starts

If the zip is compressed (rarely tho), the direct map illusion breaks, the code handles this gracefully and just falls back to the old RAM/Temp file logic so nothing crashes.

TL;DR:
- Instant Start: Progress bars now show up almost immediately for Stored zips, No more waiting for the pre-unzip lag
- Disk Health: Saves gigabytes of redundant SSD writes every time you extract a partition
- Pure Efficiency: Bypasses the initial zip extraction overhead completely

Tested this locally on Linux, and the extraction speed is a massive W...