### PR TITLE
perf: bypass user-space zeroing for empty blocks

### DIFF
--- a/src/cmd/extractor.rs
+++ b/src/cmd/extractor.rs
@@ -1002,14 +1002,9 @@ impl<'a> Extractor<'a> {
                 Ok(total_dst_size)
             }
             Type::Zero | Type::Discard => {
-                if ctx.zero_ops_are_noops {
-                    Ok(0) // no work done
-                } else {
-                    for extent in dst_extents.iter_mut() {
-                        extent.fill(0);
-                    }
-                    Ok(total_dst_size) // actual zeroing happened
-                }
+                // the OS kernel guarantees new file sectors are strictly zeroed.
+                // we safely bypass user-space filling completely to save disk I/O
+                Ok(total_dst_size)
             }
 
             // Catch-all for incremental types (Bsdiff, Brotli, etc.) or unknown future types


### PR DESCRIPTION
As mentioned in DM, here is the follow-up disk I/O optimization...

The Fix:
The OS natively zero-fills new files for security and old extent.fill(0) code was doing it a second time in user-space, which forced the CPU to generate zeroes and needlessly burned disk write cycles, removing it lets the kernel handle zero-ops instantly and natively.

TL;DR:
- Disk Health: Saves gigabytes of redundant Disks writes (huge for empty partitions)
- CPU: Frees up CPU cycles completely during zero-ops