### PR TITLE
perf: use posix_fallocate on Linux to fix write contention

### DIFF
--- a/src/cmd/extractor.rs
+++ b/src/cmd/extractor.rs
@@ -1316,6 +1316,22 @@ impl<'a> Extractor<'a> {
             let file = opts
                 .open(&path)
                 .with_context(|| format!("unable to open file for writing: {path:?}"))?;
+
+            // Linux-only optimization: Pre-allocate physical disk blocks
+            // this prevents sparse file fragmentation and eliminates filesystem lock
+            // contention when dozens of threads are writing randomly.
+            #[cfg(target_os = "linux")]
+            {
+                use std::os::unix::io::AsRawFd;
+                unsafe {
+                    let fd = file.as_raw_fd();
+                    let ret = libc::posix_fallocate(fd, 0, partition_len as libc::off_t);
+                    if ret != 0 {
+                        eprintln!("Warning: posix_fallocate failed (code {}), Extraction continues but may be fragmented", ret);
+                    }
+                }
+            }
+
             file.set_len(partition_len)?;
             
             let mut mmap_mut = unsafe { MmapMut::map_mut(&file) }


### PR DESCRIPTION
when we just use file.set_len(), Linux creates a sparse file, Once the threadpool starts hitting it with random writes, the filesystem chokes on lock contention trying to allocate free blocks on the fly

This adds posix_fallocate to reserve the physical disk space upfront.

- Kills the allocation locking overhead during extraction
- Prevents disk fragmentation (which speeds up the final SHA-256 check)
- Falls back safely to sparse allocation if the filesystem doesn't support it

Note: Kept this linux-only intentionally, because the windows equivalent requires Admin privileges, which would just trigger permission crashes for normal users...