### PR TITLE
feat: Clean up CLI Metadata Banner & Streamline arbscan Logging (v3.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,22 @@
 # Changelog
 
-## **otaripper v3.2.0** (Unreleased)
+## **otaripper v3.2.1** (2026-05-26)
 
 ### Smart Firmware Metadata & UX Refinements
 
-This release significantly enhances the user experience by automatically parsing firmware metadata to enrich CLI outputs, extraction folder names, and ARB JSON exports, while also silencing notorious Linux GUI errors.
+This release significantly enhances the user experience by automatically parsing firmware metadata to enrich CLI outputs, extraction folder names, and ARB JSON exports, while also streamlining CLI logging and silencing notorious Linux GUI errors.
 
-* **Firmware Information Extraction**
-  * `otaripper` now automatically parses `META-INF/com/android/metadata` and `payload_properties.txt` from OTA zips before extraction begins.
-  * Prints a beautiful "Firmware Information" banner detailing OS Version, Security Patch, and OTA Target versions directly in the terminal.
+* **Firmware Information Banner**
+  * Automatically parses `META-INF/com/android/metadata` and `payload_properties.txt` from OTA packages before extraction begins.
+  * Prints a beautiful, clean "Firmware Information" banner detailing Product Model, Android Version, Build Version, OxygenOS/ColorOS Version, and Security Patch level.
+* **Streamlined Command Line Output**
+  * Simplified the `arb` (arbscan) subcommand output: displays only the filename being analyzed (e.g., `Analyzing: xbl_config.img`) and hides long paths or remote CDN URL parameters.
+  * Cleaned up the main firmware information display to hide redundant or confusing internal target versions and update type fields.
 * **Dynamic Output Folder Naming**
-  * The extraction output directory is now dynamically named using the actual OS version string if found (e.g., `extracted_CPH2573_15.0.0.860(EX01)_2026-05-25...`) instead of just a generic timestamp.
+  * The extraction output directory is now dynamically named using the actual OS build version string if found (e.g., `extracted_CPH2573_15.0.0.860(EX01)_2026-05-26...`) instead of just a generic timestamp.
 * **Intelligent ARB Auto-Detection**
-  * The `arb` subcommand now automatically inherits the firmware metadata parsing logic.
-  * It auto-detects the device model and OS version, securely skipping the manual user prompts and directly formatting the JSON output file (e.g., `CPH2573_15.0.0.860(EX01)_ARB(0).json`).
-  * Gracefully falls back to offering detected metadata as a default suggestion for custom ROMs missing complete version strings.
+  * The `arb` subcommand automatically inherits the firmware metadata parsing logic.
+  * It auto-detects the device model and OS version, securely skipping the manual user prompts and directly formatting the JSON output filename (e.g., `CPH2573_15.0.0.860(EX01)_ARB(0).json`).
 * **Silenced Qt Terminal Spam**
   * Explicitly redirects `stdout` and `stderr` to `/dev/null` when spawning GUI file managers (like Dolphin) post-extraction, completely silencing the notorious `QPixmap::scaled: Pixmap is a null pixmap` Linux terminal spam.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "otaripper"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otaripper"
-version = "3.2.0"
+version = "3.2.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Syed Insaf <syedinsaf@proton.me>"]

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Unlike many extraction tools, otaripper **verifies output images by default** an
 
 otaripper automatically detects CPU capabilities and selects the optimal execution path.
 
-Version **3.2** introduces smart metadata parsing, parallel chunked Remote HTTP Streaming, and massive I/O savings:
+Version **3.2.1** introduces smart metadata parsing, parallel chunked Remote HTTP Streaming, and massive I/O savings:
 
 * **Parallel HTTP Streaming**: Extract specific partitions directly from a remote URL! otaripper intelligently streams only the required byte-ranges over the network, using multiple parallel 8MB chunked requests to saturate your bandwidth.
 * **Network Resilience**: Built-in automatic retries with exponential backoff and real-time offline detection. Never fail an extraction due to a temporary connection drop again.
@@ -245,7 +245,7 @@ Instantly check the ARB index of a firmware update without downloading the massi
 ```text
 $ otaripper arb https://example.com/firmware.zip
 [arbscan] OTA package detected. Extracting xbl_config.img temporarily...
-[arbscan] Analyzing: xbl_config.img (from https://example.com/firmware.zip)
+[arbscan] Analyzing: xbl_config.img
 
 OEM Metadata
 ────────────

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -2,8 +2,8 @@
 
 This document provides detailed technical information about **otaripper’s** architecture, design decisions, and implementation details.
 
-> **v3.1 Note:**
-> This release introduces Parallel Chunked HTTP Streaming and massive network resilience hardening. It features multi-threaded Range requests, a dedicated bandwidth monitor, and dynamic resolver selection to ensure flawless remote extraction across Linux, Windows, and Android environments. **v3.1.2** adds smart firmware metadata extraction, dynamic folder naming, and GUI terminal silencing.
+> **v3.2.1 Note:**
+> This release introduces Parallel Chunked HTTP Streaming, massive network resilience hardening, smart firmware metadata extraction, dynamic folder naming, simplified terminal log outputs, and GUI terminal silencing.
 
 ---
 

--- a/src/cmd/arbscan.rs
+++ b/src/cmd/arbscan.rs
@@ -397,16 +397,8 @@ fn do_run(
     let minor = read_le32(&seg, oem_md_off + 4).unwrap_or(0);
     let arb = read_le32(&seg, oem_md_off + 8).unwrap_or(0);
 
-    if path == original_path {
-        println!("[arbscan] Analyzing: {}\n", original_path.display());
-    } else {
-        let file_name = path.file_name().unwrap_or_default().to_string_lossy();
-        println!(
-            "[arbscan] Analyzing: {} (from {})\n",
-            file_name,
-            original_path.display()
-        );
-    }
+    let file_name = path.file_name().unwrap_or_default().to_string_lossy();
+    println!("[arbscan] Analyzing: {}\n", file_name);
 
     println!("OEM Metadata");
     println!("────────────");

--- a/src/cmd/extractor.rs
+++ b/src/cmd/extractor.rs
@@ -248,17 +248,39 @@ impl<'a> Extractor<'a> {
             if !self.cmd.quiet {
                 println!("Firmware Information");
                 println!("────────────────────");
-                let display_keys = [
-                    ("version_name", "OS Version"),
-                    ("oplus_rom_version", "ColorOS/OxygenOS Version"),
-                    ("ota_target_version", "OTA Target Version"),
-                    ("security_patch", "Security Patch"),
-                ];
-                for (key, label) in display_keys.iter() {
-                    if let Some(value) = meta.get(*key) {
-                        println!("{:<26} : {}", label, value);
+
+                // 1. Device Model
+                if let Some(model) = meta.get("product_name").or(meta.get("pre-device")) {
+                    println!("{:<26} : {}", "Product Model", model);
+                }
+
+                // 2. Android Version
+                if let Some(android_ver) = meta.get("android_version") {
+                    println!("{:<26} : {}", "Android Version", android_ver);
+                }
+
+                // 3. Build/OS Version
+                if let Some(build_ver) = meta.get("version_name").or(meta.get("post-build")) {
+                    println!("{:<26} : {}", "Build Version", build_ver);
+                }
+
+                // 4. ColorOS/OxygenOS Version
+                if let Some(rom_ver) = meta.get("oplus_rom_version").or(meta.get("os_version")) {
+                    // Avoid duplicating version_name if os_version happens to equal version_name
+                    if let Some(version_name) = meta.get("version_name") {
+                        if rom_ver != version_name {
+                            println!("{:<26} : {}", "OxygenOS/ColorOS Version", rom_ver);
+                        }
+                    } else {
+                        println!("{:<26} : {}", "OxygenOS/ColorOS Version", rom_ver);
                     }
                 }
+
+                // 5. Security Patch
+                if let Some(patch) = meta.get("security_patch") {
+                    println!("{:<26} : {}", "Security Patch", patch);
+                }
+
                 println!();
             }
         }


### PR DESCRIPTION
This PR introduces **otaripper v3.2.1** with CLI output cleanup and metadata layout refinements:

* **Streamlined arbscan Output**: Displays only the filename being analyzed (e.g. `Analyzing: xbl_config.img`) to hide long paths and temporary CDN URLs.
* **Polished Firmware Banner**: Reorganized the metadata display to show Product Model and Android Version while removing the redundant Update Type and confusing internal build tags.

