### PR TITLE
Add support for zstd payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "zip",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ zip = { version = "8.6.0", default-features = false, features = [
   "bzip2",
   "zstd",
 ] }
+zstd = "0.13.3"
 libc = "0.2.186"
 
 # Compatibility: Static liblzma only on musl to avoid glibc x86-64-v4 issues

--- a/src/cmd/extractor.rs
+++ b/src/cmd/extractor.rs
@@ -1185,6 +1185,15 @@ impl<'a> Extractor<'a> {
                 }
                 Ok(())
             }
+            Type::ReplaceZstd => {
+                let data = self.extract_data(op, payload, pb, total_dst_size)?;
+                let mut decoder = zstd::stream::read::Decoder::new(&*data)?;
+                self.run_op_replace(&mut decoder, &mut dst_extents, block_size, simd)?;
+                if matches!(payload.data, crate::payload::PayloadData::Local(_)) {
+                    pb.inc(total_dst_size as u64);
+                }
+                Ok(())
+            }
             Type::Zero | Type::Discard => {
                 // the OS kernel guarantees new file sectors are strictly zeroed.
                 // we safely bypass user-space filling completely to save disk I/O

--- a/src/proto/chromeos_update_engine.rs
+++ b/src/proto/chromeos_update_engine.rs
@@ -144,6 +144,10 @@ pub mod install_operation {
         /// On minor version 9 or newer, these operations are supported:
         Lz4diffBsdiff = 12,
         Lz4diffPuffdiff = 13,
+        /// On minor version 10 or newer, these operations are supported:
+        ///
+        /// Replace destination extents w/ attached zstd data.
+        ReplaceZstd = 14,
     }
     impl Type {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -166,6 +170,7 @@ pub mod install_operation {
                 Self::Zucchini => "ZUCCHINI",
                 Self::Lz4diffBsdiff => "LZ4DIFF_BSDIFF",
                 Self::Lz4diffPuffdiff => "LZ4DIFF_PUFFDIFF",
+                Self::ReplaceZstd => "REPLACE_ZSTD",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -185,6 +190,7 @@ pub mod install_operation {
                 "ZUCCHINI" => Some(Self::Zucchini),
                 "LZ4DIFF_BSDIFF" => Some(Self::Lz4diffBsdiff),
                 "LZ4DIFF_PUFFDIFF" => Some(Self::Lz4diffPuffdiff),
+                "REPLACE_ZSTD" => Some(Self::ReplaceZstd),
                 _ => None,
             }
         }


### PR DESCRIPTION
Some ota such as vivo use zstd compression. Let's add support for it too.

```console
xetob@DESKTOP-7E2AH1S:~$ ./otaripper 2026061619420543f8418507aa34f5f780dff3b34ab732.zip -p system -n
Firmware Information
────────────────────
Product Model              : PD2465
Build Version              : vivo/PD2465/PD2465:16/BP2A.250605.031.A3/compiler260616155418:user/release-keys


Extraction in progress: do NOT close this window! Use Ctrl+C to cancel safely.
Processing 1 partitions using 12 threads...

                  system [======================================================================================================] 100%
Extraction completed successfully!
Output directory: /home/xetob/extracted_2026-08-28_18-26-36
Total extracted size: 8.24 GiB
Tool Source: https://github.com/syedinsaf/otaripper
xetob@DESKTOP-7E2AH1S:~$ file extracted_2026-08-28_18-26-36/system.img
extracted_2026-08-28_18-26-36/system.img: EROFS filesystem, compat: SB_CHKSUM MTIME, blocksize=12, exslots=0, uuid=C8CBFB73-41C9-C655-A927-5EAA41DAD5DD, incompat: LZ4_0PADDING
xetob@DESKTOP-7E2AH1S:~$ fsck.erofs --extract extracted_2026-08-28_18-26-36/system.img
xetob@DESKTOP-7E2AH1S:~$ 
```